### PR TITLE
Minor fix to the alignment of the twitter share button

### DIFF
--- a/src/Components/Navbar/navbar.component.jsx
+++ b/src/Components/Navbar/navbar.component.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import { Flex, Image, Link } from "@chakra-ui/react";
 import { motion } from "framer-motion";
 import Logo from "../../Assets/logo.png";
+import "./navbar.styles.css";
 
 function Navbar() {
   const MotionImage = motion(Image);

--- a/src/Components/Navbar/navbar.styles.css
+++ b/src/Components/Navbar/navbar.styles.css
@@ -1,0 +1,3 @@
+.twitter-share-button {
+    margin-block: auto;
+}


### PR DESCRIPTION
# Description

Minor fix to the Twitter share button. The rendered twitter share button currently aligns to the top of the header which results in a bit of a weird look. I added a new style rule to adjust it back into place so it looks more clean. Screenshots provided below

Tested on :
- Firefox
- Chromium

## Type of change

- Bug fix (non-breaking change which fixes an issue)


## Screenshots

Before:

![before](https://user-images.githubusercontent.com/11588132/135472524-9ffaab3a-e4ea-457d-b4ee-f670d93c94e6.png)

After :

![after](https://user-images.githubusercontent.com/11588132/135472528-400e34ab-5784-4612-a683-1df41f816f98.png)
